### PR TITLE
Consistent and accurate caret '^' placement in error messages

### DIFF
--- a/gifts/swaDecoder.py
+++ b/gifts/swaDecoder.py
@@ -149,15 +149,20 @@ class Decoder(tpg.Parser):
                 else:
                     err_msg = 'Unidentified group '
 
+                tacLines = swa.split('\n')
+                debugString = '\n%%s\n%%%dc\n%%s' % self.lexer.cur_token.end_column
+                errorInTAC = debugString % ('\n'.join(tacLines[:self.lexer.cur_token.end_line]), '^',
+                                            '\n'.join(tacLines[self.lexer.cur_token.end_line:]))
+                self._Logger.info('%s\n%s' % (errorInTAC, err_msg))
+
                 err_msg += 'at line %d column %d.' % (self.lexer.cur_token.end_line, self.lexer.cur_token.end_column)
                 self.swa['err_msg'] = err_msg
-                self._Logger.info('%s\n%s' % (swa, self.swa['err_msg']))
 
-            return self.swa
 
         except Exception:
             self._Logger.exception(swa)
-            return self.swa
+        
+        return self.finish()
 
     def _is_a_test(self):
         return 'status' in self.swa and self.swa['status'] == 'TEST'

--- a/gifts/tcaDecoder.py
+++ b/gifts/tcaDecoder.py
@@ -118,15 +118,19 @@ class Decoder(tpg.Parser):
                 else:
                     err_msg = 'Unidentified group '
 
+                tacLines = tca.split('\n')
+                debugString = '\n%%s\n%%%dc\n%%s' % self.lexer.cur_token.end_column
+                errorInTAC = debugString % ('\n'.join(tacLines[:self.lexer.cur_token.end_line]), '^',
+                                            '\n'.join(tacLines[self.lexer.cur_token.end_line:]))
+                self._Logger.info('%s\n%s' % (errorInTAC, err_msg))
+
                 err_msg += 'at line %d column %d.' % (self.lexer.cur_token.end_line, self.lexer.cur_token.end_column)
                 self.tca['err_msg'] = err_msg
-                self._Logger.info('%s\n%s' % (tca, err_msg))
-
-            return self.tca
 
         except Exception:
             self._Logger.exception(tca)
-            return self.tca
+
+        return self.finish()
 
     def _is_a_test(self):
         return 'status' in self.tca and self.tca['status'] == 'TEST'

--- a/gifts/vaaDecoder.py
+++ b/gifts/vaaDecoder.py
@@ -161,7 +161,7 @@ class Decoder(tpg.Parser):
                 else:
                     err_msg = 'Unidentified group '
 
-                tacLines = tac.split('\n')
+                tacLines = vaa.split('\n')
                 debugString = '\n%%s\n%%%dc\n%%s' % self.lexer.cur_token.end_column
                 errorInTAC = debugString % ('\n'.join(tacLines[:self.lexer.cur_token.end_line]), '^',
                                             '\n'.join(tacLines[self.lexer.cur_token.end_line:]))
@@ -173,7 +173,7 @@ class Decoder(tpg.Parser):
         except MissingAirSpaceWinds as msg:
 
             if not self._is_a_test():
-                tacLines = tac.split('\n')
+                tacLines = vaa.split('\n')
                 debugString = '\n%%s\n%%%dc\n%%s' % msg.column
                 errorInTAC = debugString % ('\n'.join(tacLines[:msg.line]), '^',
                                             '\n'.join(tacLines[msg.line:]))
@@ -183,7 +183,7 @@ class Decoder(tpg.Parser):
         except Exception:
             self._Logger.exception(vaa)
 
-        return self.vaa
+        return self.finish()
 
     def _is_a_test(self):
         try:


### PR DESCRIPTION
Corrected placement of '^' character in VAA messages.  Added similar error reporting styles to TCA and SWA decoders as well.