### PR TITLE
44 regexp no greedy

### DIFF
--- a/gifts/swaDecoder.py
+++ b/gifts/swaDecoder.py
@@ -102,7 +102,7 @@ class Decoder(tpg.Parser):
                                 'fcsthr': 'FCST SWX +nn HR', 'rmk': 'RMK:',
                                 'nextdtg': 'Next advisory issuance date/time', 'noadvisory': 'NO FURTHER ADVISORIES'}
 
-        self.header = re.compile(r'.*(?=SWX ADVISORY)', re.DOTALL)
+        self.header = re.compile(r'.*?(?=SWX ADVISORY)', re.DOTALL)
 
         setattr(self, 'lat_band', self.add_region)
         setattr(self, 'point', self.add_region)

--- a/gifts/tcaDecoder.py
+++ b/gifts/tcaDecoder.py
@@ -84,7 +84,7 @@ class Decoder(tpg.Parser):
                                 'cfpsn': 'Forecast Position', 'cfwnd': 'Forecast Maximum Wind Speed', 'rmk': 'Remarks',
                                 'nextdtg': 'Next advisory issuance time or NO MSG EXP'}
 
-        self.header = re.compile(r'.*(?=TC ADVISORY)', re.DOTALL)
+        self.header = re.compile(r'.*?(?=TC ADVISORY)', re.DOTALL)
 
         self._Logger = logging.getLogger(__name__)
         return super(Decoder, self).__init__()

--- a/gifts/vaaDecoder.py
+++ b/gifts/vaaDecoder.py
@@ -115,7 +115,7 @@ class Decoder(tpg.Parser):
                                 'rmk': 'Remarks', 'nextdtg': 'Next VAA issuance time',
                                 '_tok_2': 'dash character (-)', '_tok_3': 'dash character (-)'}
 
-        self.header = re.compile(r'.*(?=VA ADVISORY)', re.DOTALL)
+        self.header = re.compile(r'.*?(?=VA ADVISORY)', re.DOTALL)
         self._reWinds = re.compile(r'(WINDS?)?\s+(SFC|FL(?P<bottom>\d{3}))(/((FL)?(?P<top>\d{3})))?\s+(?P<dir>VRB|\d{3})/?(?P<spd>\d{1,3})(-\d{2,3})?(?P<uom>MPS|KT)')  # noqa: E501
 
         self._detail_date = re.compile(r'[\d/]{4,13}Z')

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ description = IWXXM encoders for Annex3 TAC products
 author = Mark Oberfield - NOAA/NWS/OSTI/MDL/WIAD
 author_email = Mark.Oberfield@noaa.gov
 maintainer = Mark Oberfield
-version = 1.5.0
+version = 1.5.1
 classifiers = Programming Language :: Python :: 3
     Operating System :: OS Independent
     Topic :: Text Processing :: Markup :: XML

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ exclude = tests
 [options.extras_require]
 test =
     flake8>=3.7,<4a0
-    pytest>=4.6,<5a0
+    pytest>=8.3
     pytest-cov>=2.7,<3a0
 
 [aliases]

--- a/tests/test_swa_encoding.py
+++ b/tests/test_swa_encoding.py
@@ -7,6 +7,7 @@ import gifts.common.xmlConfig as des
 SWAEncoder = SWAE.Encoder()
 decoder = SD.Decoder()
 encoder = SE.Encoder()
+des.TRANSLATOR = True
 
 first_siblings = ['issueTime', 'issuingSpaceWeatherCentre', 'advisoryNumber', 'phenomenon', 'phenomenon', 'analysis',
                   'analysis', 'analysis', 'analysis', 'analysis', 'remarks', 'nextAdvisoryTime']
@@ -213,9 +214,35 @@ NXT ADVISORY:       WILL BE ISSUED BY 20161108/0100Z"""
     assert len(bulletin) == 1
 
 
+def test_multipleAdvisoryStrings():
+
+    test = """FNXX01 KWNP 080106
+SWX ADVISORY
+STATUS:             TEST
+DTG:                20161108/0100Z
+SWXC:               DONLON
+ADVISORY NR:        2016/1
+NR RPLC:            2015/325
+SWX EFFECT:         HF COM SEV
+FCST SWX:           08/0100Z DAYLIGHT SIDE ABV FL400
+FCST SWX +6 HR:     08/0700Z DAYLIGHT SIDE FL350-500
+FCST SWX +12 HR:    08/1300Z DAYLIGHT SIDE
+FCST SWX +18 HR:    08/1900Z S4530 E01545 - S4100 W01300 - S3230 W02530 - S2930 W03715 - S3630 W04630 - S3815 W04445 -
+                             S3345 E03800 - S3330 W03230 - S3800 W02330 - S4530 W01545
+FCST SWX +24 HR:    09/0100Z N4530 E01545 - N3800 E02330 - N3330 E03230 - N3345 E03800 - N3815 E04445 - N3630 E04630 -
+                             N2930 E03715 - N3230 E02530 - N4100 E01300 - N4530 E01545
+RMK:                PERIODIC HF COM ABSORPTION OBS AND LIKELY TO CONT IN THE NEAR TERM. CMPL AND PERIODIC LOSS OF HF ON
+THE SUNLIT SIDE OF THE EARTH EXP. CONT HF COM DEGRADATION LIKELY OVER THE NXT 7 DAYS. SEE WWW.SPACEWEATHERPROVIDER.WEB
+THIS IS A TEST SWX ADVISORY.
+NXT ADVISORY:       20161108/0700Z="""
+    result = decoder(test)
+    assert 'err_msg' not in result
+
+
 if __name__ == '__main__':
 
     test_swaFailureModes()
     test_swaTest()
     test_swaExercise()
     test_swaNormal()
+    test_multipleAdvisoryStrings()

--- a/tests/test_tca_encoding.py
+++ b/tests/test_tca_encoding.py
@@ -732,6 +732,39 @@ NXT MSG:                  NO MSG EXP
             assert element.get('nilReason') == codes[des.NIL][des.NA][0]
 
 
+def test_multipleAdvisoryStrings():
+
+    import gifts.tcaDecoder as tD
+    decoder = tD.Decoder()
+
+    test = """FKPQ30 RJTD 111800
+TC ADVISORY
+STATUS:               TEST
+DTG:                  20180911/1800Z
+TCAC:                 TOKYO
+TC:                   MANGKHUT
+ADVISORY NR:          2018/19
+OBS PSN:              11/1800Z N1400 E13725
+CB:                   WI 180NM OF TC CENTRE TOP ABV FL450
+MOV:                  W 12KT
+INTST CHANGE:         INTSF
+C:                    905HPA
+MAX WIND:             110KT
+FCST PSN +6 HR:       12/0000Z N1405 E13620
+FCST MAX WIND +6 HR:  110KT
+FCST PSN +12 HR:      12/0600Z N1420 E13510
+FCST MAX WIND +12 HR: 110KT
+FCST PSN +18 HR:      12/1200Z N1430 E134
+FCST MAX WIND +18 HR: 110KT
+FCST PSN +24 HR:      12/1800Z N1450 E13250
+FCST MAX WIND +24 HR: 110KT
+RMK:                  THIS IS A TEST TCA ADVISORY
+NXT MSG:              BFR 20180912/0000Z=
+"""
+    result = decoder(test)
+    assert 'err_msg' not in result
+
+
 if __name__ == '__main__':
 
     test_tcaFailureModes()
@@ -742,3 +775,4 @@ if __name__ == '__main__':
     test_tcaMetric()
     test_developing()
     test_dissipation()
+    test_multipleAdvisoryStrings()

--- a/tests/test_vaa_encoding.py
+++ b/tests/test_vaa_encoding.py
@@ -881,6 +881,36 @@ NXT ADVISORY: NO FURTHER ADVISORIES
     assert element.get('nilReason') == codes[des.NIL][des.NA][0]
 
 
+def test_multipleAdvisoryStrings():
+
+    import gifts.vaaDecoder as vD
+    decoder = vD.Decoder()
+
+    test = """FVXX27 KNES 191645
+VA ADVISORY
+DTG: 20240319/1645Z
+VAAC: WASHINGTON
+VOLCANO: TEST 999999
+PSN: N3700 W07700
+AREA: US
+SUMMIT ELEV: 32805 FT (9999 M)
+ADVISORY NR: 2024/001
+INFO SOURCE: TEST
+ERUPTION DETAILS: TEST AT 19/1700Z
+OBS VA DTG: 19/1645Z
+OBS VA CLD: VA NOT IDENTIFIABLE FROM SATELLITE
+DATA WIND FL100 300/10KTS
+FCST VA CLD +6HR: 19/2300Z NO VA EXP
+FCST VA CLD +12HR: 20/0500Z NO VA EXP
+FCST VA CLD +18HR: 20/1100Z NO VA EXP
+RMK: THIS IS A VA ADVISORY TEST MSG. MWO TAHITI
+SHOULD NOW ISSUE A SIGMET TEST MSG FOR VA
+ADVISORY IF RECEIVED. ...KIBLER
+NXT ADVISORY:  NO FURTHER ADVISORIES
+"""
+    result = decoder(test)
+    assert 'err_msg' not in result
+
 if __name__ == '__main__':
 
     test_vaaFailureModes()
@@ -891,3 +921,4 @@ if __name__ == '__main__':
     test_vaaNormal()
     test_unknowns()
     test_resuspendedash()
+    test_multipleAdvisoryStrings()


### PR DESCRIPTION
Revised the VAA regexp string that locates the beginning of the advisory message to stop at the first match in the TAC.  Although unlikely, the same regexp string fix was applied to TCA and SWA decoders too.  Added new tests of duplicate start strings in all advisory TACs.

Because this is a bug fix, versioning changes from 1.5.0 to 1.5.1.

In addition, version of the pytest module used to run 'make test' has been updated to 8.3 or better. 